### PR TITLE
fix ecdsa issues, upgrade to 3.3.x and documentation changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,19 @@ OBJS += $(subst .c,.o,$(SRCS))
 	$(CC) $(CFLAGS) $(DEBUG) -fPIC -c $<
 
 dpdk_engine.so: $(OBJS) Makefile $(PC_FILE)
+# chacha-armv8-sve.S file is present in openssl versions >= 3.1, not in 1.1.x
+ifneq ("$(wildcard $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8-sve.S)","")
+	$(CC) $(CFLAGS) -shared $(OBJS) -o $@ $(LDFLAGS) $(LDFLAGS_SHARED) $(OPENSSL_INSTALL)/crypto/aes/aesv8-armx.S $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8.S  $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8-sve.S  $(OPENSSL_INSTALL)/crypto/poly1305/poly1305.c $(OPENSSL_INSTALL)/crypto/poly1305/poly1305-armv8.S $(OPENSSL_INSTALL)/crypto/armcap.c $(OPENSSL_INSTALL)/crypto/arm64cpuid.S
+else
 	$(CC) $(CFLAGS) -shared $(OBJS) -o $@ $(LDFLAGS) $(LDFLAGS_SHARED) $(OPENSSL_INSTALL)/crypto/aes/aesv8-armx.S $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8.S  $(OPENSSL_INSTALL)/crypto/poly1305/poly1305.c $(OPENSSL_INSTALL)/crypto/poly1305/poly1305-armv8.S $(OPENSSL_INSTALL)/crypto/armcap.c $(OPENSSL_INSTALL)/crypto/arm64cpuid.S
+endif
 
 $(APP)-static: $(OBJS) Makefile $(PC_FILE)
+ifneq ("$(wildcard $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8-sve.S)","")
+	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS) $(LDFLAGS_STATIC) $(OPENSSL_INSTALL)/crypto/aes/aesv8-armx.S $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8.S $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8-sve.S $(OPENSSL_INSTALL)/crypto/poly1305/poly1305.c $(OPENSSL_INSTALL)/crypto/poly1305/poly1305-armv8.S $(OPENSSL_INSTALL)/crypto/armcap.c $(OPENSSL_INSTALL)/crypto/arm64cpuid.S
+else
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS) $(LDFLAGS_STATIC) $(OPENSSL_INSTALL)/crypto/aes/aesv8-armx.S $(OPENSSL_INSTALL)/crypto/chacha/chacha-armv8.S $(OPENSSL_INSTALL)/crypto/poly1305/poly1305.c $(OPENSSL_INSTALL)/crypto/poly1305/poly1305-armv8.S $(OPENSSL_INSTALL)/crypto/armcap.c $(OPENSSL_INSTALL)/crypto/arm64cpuid.S
+endif
 
 clean:
 	rm -fr $(OBJS) dpdk_engine.so

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -313,6 +313,7 @@ IV) Supported Features
   f) Running multi-process applications with openssl.cnf file
      Due to the limitations of DPDK, forking applications need to ensure that openssl.cnf file is loaded after fork().
      With openssl speed with -multi option, use OPENSSL_CONF_MULTI env instead of OPENSSL_CONF for this reason.
+     Engine is loaded from openssl.cnf, do not use -engine argument when OPENSSL_CONF_MULTI is employed.
 
     # OPENSSL_CONF_MULTI=openssl.cnf openssl speed -multi 4 -elapsed rsa2048
 

--- a/e_dpdkcpt_cpoly.c
+++ b/e_dpdkcpt_cpoly.c
@@ -20,7 +20,11 @@
 #include <openssl/crypto.h>
 #include <crypto/poly1305.h>
 #include <crypto/chacha.h>
+#if OPENSSL_API_LEVEL >= 30000
+#include <openssl/evp.h>
+#else
 #include <evp_local.h>
+#endif
 
 #include <rte_eal.h>
 #include <rte_errno.h>

--- a/e_dpdkcpt_gcm.c
+++ b/e_dpdkcpt_gcm.c
@@ -17,8 +17,13 @@
 #include <openssl/modes.h>
 #include <openssl/aes.h>
 #include <openssl/crypto.h>
+#if OPENSSL_API_LEVEL >= 30000
+#include <crypto/modes.h>
+#include <openssl/evp.h>
+#else
 #include <modes_local.h>
 #include <evp_local.h>
+#endif
 
 #include <rte_eal.h>
 #include <rte_mempool.h>


### PR DESCRIPTION
1. update engine usage readme with OPENSSL_CONF_MULTI
2. address issue with ecdsa sign/verify code
3. openssl 3.x compatible changes
4. fix ecdsa verify failure
